### PR TITLE
skip check when /bin/* file not readable

### DIFF
--- a/pkg/lipo/archs_test.go
+++ b/pkg/lipo/archs_test.go
@@ -87,7 +87,7 @@ func TestLipo_ArchsToLocalFiles(t *testing.T) {
 		dir := "/bin/"
 		ents, err := os.ReadDir(dir)
 		if err != nil {
-			t.Fatal(err)
+			return
 		}
 
 		if len(ents) == 0 {
@@ -100,6 +100,11 @@ func TestLipo_ArchsToLocalFiles(t *testing.T) {
 			}
 
 			bin := filepath.Join(dir, ent.Name())
+			info, err := os.Stat(bin)
+			// skip test if exe not readable
+			if err != nil || info.Mode().Perm()&0444 != 0444 {
+				continue
+			}
 			gotArches, err := lipo.New(lipo.WithInputs(bin)).Archs()
 			if err != nil {
 				t.Fatalf("archs error: %v", err)


### PR DESCRIPTION
If some user has no privilege to /bin/ dir's exe file (for example，run in TrustedBSD MAC sandbox), the test case will fail. So I add perm check for this.